### PR TITLE
ci: add parameter to run update for a different date.

### DIFF
--- a/.github/workflows/run-rpl-cralwer.yml
+++ b/.github/workflows/run-rpl-cralwer.yml
@@ -1,6 +1,10 @@
 name: Run RPL Crawler
 on:
   workflow_dispatch:
+    inputs:
+      date:
+        description: 'Date of publication of RPL'
+        required: false
   schedule:
     - cron: '0 0 * * *'
 jobs:
@@ -15,4 +19,5 @@ jobs:
       - name: Run Update
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE $(date +"%Y-%m-%d")
+          RPL_DATE: ${{ github.event.inputs.date }} || $(date +"%Y-%m-%d")
+        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE $RPL_DATE

--- a/.github/workflows/run-rpl-cralwer.yml
+++ b/.github/workflows/run-rpl-cralwer.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Run Update
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-          RPL_DATE: ${{ github.event.inputs.date }} || $(date +"%Y-%m-%d")
-        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE $RPL_DATE
+          RPL_DATE: ${{ github.event.inputs.date }}
+        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE ${RPL_DATE:-(date +"%Y-%m-%d")}

--- a/.github/workflows/run-rpl-cralwer.yml
+++ b/.github/workflows/run-rpl-cralwer.yml
@@ -20,4 +20,4 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           RPL_DATE: ${{ github.event.inputs.date }}
-        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE ${RPL_DATE:-(date +"%Y-%m-%d")}
+        run: docker run -e DATABASE_URL=$(heroku config:get DATABASE_URL --app=mach-api) ghcr.io/jpedroh/mach-rpl-crawler:latest node packages/rpl-crawler/dist/main SBAZ,SBBS,SBCW,SBRE ${RPL_DATE:-$(date +"%Y-%m-%d")}

--- a/.github/workflows/run-rpl-cralwer.yml
+++ b/.github/workflows/run-rpl-cralwer.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       date:
-        description: 'Date of publication of RPL'
+        description: 'Date of publication of RPL (YYYY-MM-DD)'
         required: false
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Sometimes, due to a failure on crawler job or some other requirement, it's necessary to run the crawler for a different Date than the current one. This PR adds this possibility through a `workflow_dispatch` parameter.