### PR TITLE
fix: use substring instead of regex capture for departure ICAO.

### DIFF
--- a/packages/rpl-crawler/src/flight-decoder/flight-decoder.ts
+++ b/packages/rpl-crawler/src/flight-decoder/flight-decoder.ts
@@ -16,7 +16,7 @@ const makeFlightDecoder = ({ uuid }: { uuid: (line: string) => string }) => {
     const endDate = LINE_1.match(/(?<= )(\d{6}|( ){6})(?= [I|V|Y|Z])/)[0]
     const company = callsign.match(/[A-Z]+/)[0];
     const flightNumber = Number(callsign.match(/\d+/)[0]);
-    const departureIcao = LINE_1.match(/[A-Z]{4}/)[0];
+    const departureIcao = LINE_1.substring(44, 48);
     const estimatedOffBlockTime = LINE_1.match(/\d{4}$/)[0]
     const flightRules = LINE_1.match(/(?<= ).(?=[A-Z] )/)[0]
     const weekDays = LINE_1.match(/(?<= )(\d| ){7}(?= )/)[0].trim();

--- a/packages/rpl-crawler/src/flight-decoder/flight-decoder.ts
+++ b/packages/rpl-crawler/src/flight-decoder/flight-decoder.ts
@@ -16,7 +16,7 @@ const makeFlightDecoder = ({ uuid }: { uuid: (line: string) => string }) => {
     const endDate = LINE_1.match(/(?<= )(\d{6}|( ){6})(?= [I|V|Y|Z])/)[0]
     const company = callsign.match(/[A-Z]+/)[0];
     const flightNumber = Number(callsign.match(/\d+/)[0]);
-    const departureIcao = LINE_1.substring(44, 48);
+    const departureIcao = LINE_1.substr(-9, 4);
     const estimatedOffBlockTime = LINE_1.match(/\d{4}$/)[0]
     const flightRules = LINE_1.match(/(?<= ).(?=[A-Z] )/)[0]
     const weekDays = LINE_1.match(/(?<= )(\d| ){7}(?= )/)[0].trim();

--- a/packages/rpl-crawler/src/main.ts
+++ b/packages/rpl-crawler/src/main.ts
@@ -60,7 +60,7 @@ const main = async (
     Logger.info(`STARTING DECODING OF RPL FILES DATA`)
     const flights = Array.from(filesLines).map(rawFlight => {
       try {
-        return flightDecoder
+        return flightDecoder(rawFlight);
       } catch (error) {
         Logger.info(`ERROR WHEN PARSING FLIGHT: ${rawFlight}`);
       }

--- a/packages/rpl-crawler/src/main.ts
+++ b/packages/rpl-crawler/src/main.ts
@@ -58,7 +58,13 @@ const main = async (
     Logger.info(`COMPLETED LINES EXTRACTION FROM RPL FILES`)
 
     Logger.info(`STARTING DECODING OF RPL FILES DATA`)
-    const flights = Array.from(filesLines).map(flightDecoder)
+    const flights = Array.from(filesLines).map(rawFlight => {
+      try {
+        return flightDecoder
+      } catch (error) {
+        Logger.info(`ERROR WHEN PARSING FLIGHT: ${rawFlight}`);
+      }
+    }).filter(Boolean) as Flight[];
     Logger.info(`COMPLETED DECODING OF RPL FILES DATA`)
 
     Logger.info(`STARTING SAVING DECODED DATA TO DATABASE`)

--- a/packages/rpl-crawler/src/main.ts
+++ b/packages/rpl-crawler/src/main.ts
@@ -58,13 +58,7 @@ const main = async (
     Logger.info(`COMPLETED LINES EXTRACTION FROM RPL FILES`)
 
     Logger.info(`STARTING DECODING OF RPL FILES DATA`)
-    const flights = Array.from(filesLines).map(rawFlight => {
-      try {
-        return flightDecoder(rawFlight);
-      } catch (error) {
-        Logger.info(`ERROR WHEN PARSING FLIGHT: ${rawFlight}`);
-      }
-    }).filter(Boolean) as Flight[];
+    const flights = Array.from(filesLines).map(flightDecoder)
     Logger.info(`COMPLETED DECODING OF RPL FILES DATA`)
 
     Logger.info(`STARTING SAVING DECODED DATA TO DATABASE`)


### PR DESCRIPTION
The previous implementation used the following regex to match departure ICAO: `[A-Z]{4}`. The problem with it is that airports that have numbers in its ICAO codes were not parsed correctly, thus raising an error in runtime. Since the departure ICAO code has a fixed location in the string being parsed, it's safe to just use substr to parse it.